### PR TITLE
Allow AbstractStrings

### DIFF
--- a/src/crayon_wrapper.jl
+++ b/src/crayon_wrapper.jl
@@ -3,8 +3,11 @@ struct CrayonWrapper
     v::Vector{Union{CrayonWrapper,String}}
 end
 
-function (c::Crayon)(args::Union{CrayonWrapper,String}...)
-    CrayonWrapper(c, collect(args))
+function (c::Crayon)(args::Union{CrayonWrapper,AbstractString}...)
+    typefix(cw::CrayonWrapper) = cw
+    typefix(str) = String
+    
+    CrayonWrapper(c, typefix.(collect(args)))
 end
 
 Base.show(io::IO, cw::CrayonWrapper) = _show(io, cw, CrayonStack(incremental = true))

--- a/src/crayon_wrapper.jl
+++ b/src/crayon_wrapper.jl
@@ -5,7 +5,7 @@ end
 
 function (c::Crayon)(args::Union{CrayonWrapper,AbstractString}...)
     typefix(cw::CrayonWrapper) = cw
-    typefix(str) = String
+    typefix(str) = String(str)
     
     CrayonWrapper(c, typefix.(collect(args)))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,6 +133,7 @@ print_with_color(Crayon(foreground = :red), io, "haho")
 
 # Call overloading
 @test string(Crayon()("hello")) == "hello"
+@test string(Crayon()(split("hello world")[1])) == "hello" # test substrings
 @test string(Crayon(bold=true)("hello")) == string(BOLD, "hello", inv(BOLD))
 @test string(Crayon(bold=true, foreground = :red)("hello")) == string(Crayon(foreground=:red, bold=true), "hello", Crayon(foreground=:default, bold=false))
 


### PR DESCRIPTION
I wanted to use a Crayon on a Regex capture.
But it failed as those are `SubString`s.

This is one way to fix it, by converting the inputs
The other would be to change the Struct to allow `Union{CrayonWrapper, AbstractStrings}`
which has problems of its own.