### PR TITLE
Only print escape sequences if IO supports

### DIFF
--- a/src/crayon.jl
+++ b/src/crayon.jl
@@ -103,7 +103,8 @@ Base.inv(c::Crayon) = Crayon(inv(c.fg), inv(c.bg), ANSIStyle(), # no point takin
                              inv(c.blink), inv(c.negative), inv(c.conceal), inv(c.strikethrough))
 
 function Base.print(io::IO, x::Crayon)
-    if anyactive(x) && (Base.have_color || _force_color())
+    io_have_color = get(io, :color, false)
+    if anyactive(x) && ( (Base.have_color && io_have_color) || _force_color())
         print(io, CSI)
         if (x.fg.style == COLORS_24BIT || x.bg.style == COLORS_24BIT) && _force_256_colors()
             x = _to256(x)
@@ -114,7 +115,8 @@ function Base.print(io::IO, x::Crayon)
 end
 
 function Base.show(io::IO, x::Crayon)
-    if anyactive(x)
+    io_have_color = get(io, :color, false)
+    if anyactive(x) && io_have_color
         print(io, x)
         print(io, ESCAPED_CSI)
         _print(io, x)

--- a/src/crayon.jl
+++ b/src/crayon.jl
@@ -104,7 +104,7 @@ Base.inv(c::Crayon) = Crayon(inv(c.fg), inv(c.bg), ANSIStyle(), # no point takin
 
 function Base.print(io::IO, x::Crayon)
     io_has_color = get(io, :color, false)
-    if anyactive(x) && ( (Base.have_color && io_has_color) || _force_color())
+    if anyactive(x) && (io_has_color || _force_color())
         print(io, CSI)
         if (x.fg.style == COLORS_24BIT || x.bg.style == COLORS_24BIT) && _force_256_colors()
             x = _to256(x)

--- a/src/crayon.jl
+++ b/src/crayon.jl
@@ -103,8 +103,8 @@ Base.inv(c::Crayon) = Crayon(inv(c.fg), inv(c.bg), ANSIStyle(), # no point takin
                              inv(c.blink), inv(c.negative), inv(c.conceal), inv(c.strikethrough))
 
 function Base.print(io::IO, x::Crayon)
-    io_have_color = get(io, :color, false)
-    if anyactive(x) && ( (Base.have_color && io_have_color) || _force_color())
+    io_has_color = get(io, :color, false)
+    if anyactive(x) && ( (Base.have_color && io_has_color) || _force_color())
         print(io, CSI)
         if (x.fg.style == COLORS_24BIT || x.bg.style == COLORS_24BIT) && _force_256_colors()
             x = _to256(x)
@@ -115,8 +115,8 @@ function Base.print(io::IO, x::Crayon)
 end
 
 function Base.show(io::IO, x::Crayon)
-    io_have_color = get(io, :color, false)
-    if anyactive(x) && io_have_color
+    io_has_color = get(io, :color, false)
+    if anyactive(x) && io_has_color
         print(io, x)
         print(io, ESCAPED_CSI)
         _print(io, x)


### PR DESCRIPTION
Hi @KristofferC ,

If I try to save an output of `print` with Crayons to a file, then I get a lot of escape sequences. Hence, I am proposing this PR in which the `print` of a Crayon will check if the `IO` has support for colors. It it has, then the escape sequences will be printed, otherwise they will be omitted. This behavior can be changed by the ENV key `FORCE_COLOR`.