### PR TITLE
respect :color option in show and print

### DIFF
--- a/src/crayon.jl
+++ b/src/crayon.jl
@@ -107,6 +107,7 @@ function _have_color()
     end
 end
 function Base.print(io::IO, x::Crayon)
+    get(io, :color, true) || return
     if anyactive(x) && (_have_color() || _force_color())
         print(io, CSI)
         if (x.fg.style == COLORS_24BIT || x.bg.style == COLORS_24BIT)
@@ -122,6 +123,7 @@ function Base.print(io::IO, x::Crayon)
 end
 
 function Base.show(io::IO, x::Crayon)
+    get(io, :color, true) || return
     if anyactive(x)
         print(io, x)
         print(io, ESCAPED_CSI)


### PR DESCRIPTION
This is just one *small* step towards solving #47 now turning `:color=>false` is at least making some examples (except string interp) print without color.